### PR TITLE
Fixed pattern matching fail reason

### DIFF
--- a/ch03-tuples-and-records.asciidoc
+++ b/ch03-tuples-and-records.asciidoc
@@ -50,8 +50,8 @@ Here is some sample output.
 18.84955592153876
 4> geom:area(triangle, 4, 5).
 10.0
-5> geom:area(square, -1, 3).
-** exception error: no function clause matching geom:area(square,-1,3) (geom.erl, line 18)
+5> geom:area(rectangle, -1, 3).
+** exception error: no function clause matching geom:area(rectangle,-1,3) (geom.erl, line 18)
 ----
 
 <<SOLUTION03-ET02,See a suggested solution in Appendix A.>>


### PR DESCRIPTION
This will show how matching fails because of guard, not because there's no `area(square, A, B)` clause.
