### PR TITLE
Optimized etude 6-1 suggested solution and made failing message more meaningful.

### DIFF
--- a/ch06-lists.asciidoc
+++ b/ch06-lists.asciidoc
@@ -41,10 +41,8 @@ list can't really be said to have a minimum value.
 3> stats:minimum(N).
 -17
 4> stats:minimum([]).
-** exception error: bad argument
-     in function  hd/1
-        called as hd([])
-     in call from stats:minimum/1 (stats.erl, line 15)
+** exception error: no match of right hand side value []
+     in function  stats:minimum/1 (stats.erl, line 15)
 5> stats:minimum([52.46]).
 52.46
 -----

--- a/code/ch06-01/stats.erl
+++ b/code/ch06-01/stats.erl
@@ -12,7 +12,8 @@
 -spec(minimum(list(number())) -> number()).
 
 minimum(NumberList) ->
-  minimum(NumberList, hd(NumberList)).
+  [Result | Rest] = Numbers,
+  minimum(Rest, Result).
 
 minimum([], Result) -> Result;
 


### PR DESCRIPTION
First commit does 2 things: 
- decreases number of recursive `minimum/2` calls by 1
- makes error message in case of `minimum([])` call more meaningful, IMHO, by failing to split empty list
