### PR TITLE
Added a "contributors" file

### DIFF
--- a/contributors.asciidoc
+++ b/contributors.asciidoc
@@ -1,0 +1,7 @@
+[[contributors]]
+== Contributors
+
+The author and O'Reilly Media wish to thank the people who have contributed to this project. They include:
+
+* https://github.com/draconar[Fabio "Draco" Fonseca]
+* https://github.com/develop7[Andrei Dziahel]


### PR DESCRIPTION
It would be nice to to thank the people who have contributed to the project, so I added a "contributors" file.  Basically, it's a slightly modified version of the "members" tab from the project network.
