### PR TITLE
Fix broken Wikipedia link.

### DIFF
--- a/ch08-processes.asciidoc
+++ b/ch08-processes.asciidoc
@@ -14,7 +14,7 @@ game of "War" against itself.
 The Art of War
 ^^^^^^^^^^^^^^
 These are the rules of the game as condensed from
-http://en.wikipedia.org/wiki/War_%28card_game%29,Wikipedia[Wikipedia], adapted
+link:http://en.wikipedia.org/wiki/War_(card_game)[Wikipedia], adapted
 to two players, and simplified further.
 
 Two players each take 26 cards from a shuffled deck. Each person


### PR DESCRIPTION
The link to the War rules in chap. 8 was broken for me. I found the correct article and fixed the link.
