### PR TITLE
The type of the parameter should be string().

### DIFF
--- a/code/ch05-02/dates.erl
+++ b/code/ch05-02/dates.erl
@@ -10,7 +10,7 @@
 %% @doc Takes a string in ISO date format (yyyy-mm-dd) and
 %% returns a list of integers in form [year, month, day].
 
--spec(date_parts(list()) -> list()).
+-spec(date_parts(string()) -> list()).
 
 date_parts(DateStr) ->
   [YStr, MStr, DStr] = re:split(DateStr, "-", [{return, list}]),

--- a/code/ch06-04/teeth.erl
+++ b/code/ch06-04/teeth.erl
@@ -8,7 +8,7 @@
 
 %% @doc Create a list of tooth numbers that require attention.
 
--spec(alert[integer()]) -> [integer()]).
+-spec(alert([integer()]) -> [integer()]).
 
 alert(ToothList) -> alert(ToothList, 1, []).
 


### PR DESCRIPTION
1. The ISO date is string, so you should declare string().
2. The missing parenthesis causes syntax error.
