### PR TITLE
Fixes two issues

### DIFF
--- a/code/ch05-02/dates.erl
+++ b/code/ch05-02/dates.erl
@@ -10,7 +10,7 @@
 %% @doc Takes a string in ISO date format (yyyy-mm-dd) and
 %% returns a list of integers in form [year, month, day].
 
--spec(date_parts(string()) -> list()).
+-spec(date_parts(list()) -> list()).
 
 date_parts(DateStr) ->
   [YStr, MStr, DStr] = re:split(DateStr, "-", [{return, list}]),

--- a/code/ch05-02/dates.erl
+++ b/code/ch05-02/dates.erl
@@ -10,7 +10,7 @@
 %% @doc Takes a string in ISO date format (yyyy-mm-dd) and
 %% returns a list of integers in form [year, month, day].
 
--spec(date_parts(list()) -> list()).
+-spec(date_parts(string()) -> list()).
 
 date_parts(DateStr) ->
   [YStr, MStr, DStr] = re:split(DateStr, "-", [{return, list}]),

--- a/code/ch06-04/teeth.erl
+++ b/code/ch06-04/teeth.erl
@@ -8,7 +8,7 @@
 
 %% @doc Create a list of tooth numbers that require attention.
 
--spec(alert[integer()]) -> [integer()]).
+-spec(alert([integer()]) -> [integer()]).
 
 alert(ToothList) -> alert(ToothList, 1, []).
 

--- a/code/ch06-05/non_fp.erl
+++ b/code/ch06-05/non_fp.erl
@@ -43,15 +43,15 @@ generate_tooth(ProbGood) ->
     true -> BaseDepth = 2;
     false -> BaseDepth = 3
   end,
-  generate_tooth(BaseDepth, 6, []).
+  generate_tooth(BaseDepth, 6).
 
 %% @doc Take the base depth, add a number in range -1..1 to it,
 %% and add it to the list.
 
-generate_tooth(_Base, 0, Result) -> Result;
+generate_tooth(_Base, 0) -> [];
 
-generate_tooth(Base, N, Result) ->
-  [Base + random:uniform(3) - 2 | generate_tooth(Base, N - 1, Result)].
+generate_tooth(Base, N) ->
+  [Base + random:uniform(3) - 2 | generate_tooth(Base, N - 1)].
   
 test_teeth() ->
   TList = "FTTTTTTTTTTTTTTFTTTTTTTTTTTTTTTT",


### PR DESCRIPTION
1. [code/ch06-04/teeth.erl]
   Missing the parenthesis causes syntax error. 
2. [code/ch06-05/non_fp.erl]
   Don't need to use the accumulator in the generate_tooth, as it's useless during the recursion.
